### PR TITLE
Discussion thread is private message

### DIFF
--- a/models/comment_thread.rb
+++ b/models/comment_thread.rb
@@ -123,7 +123,7 @@ class CommentThread < Content
   end
 
   def to_hash(params={})
-    as_document.slice(*%w[thread_type title body course_id anonymous anonymous_to_peers commentable_id created_at updated_at at_position_list closed context])
+    as_document.slice(*%w[thread_type title body course_id anonymous anonymous_to_peers private_to_peers commentable_id created_at updated_at at_position_list closed context])
         .merge('id' => _id,
                'user_id' => author_id,
                'username' => author_username,


### PR DESCRIPTION
Add private_to_peers field to model slicer, when forum creates a new ThreadPresenter Object. 
